### PR TITLE
fix: adjust the timeout range to include check_is_dirty()

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,6 +1,6 @@
 #ifndef _VERSION_H_
 #define _VERSION_H_
 
-#define VERSION "1.0.3"
+#define VERSION "1.0.4"
 
 #endif

--- a/wchkdsk.h
+++ b/wchkdsk.h
@@ -50,7 +50,7 @@ typedef enum {
 #define FILESYSTEM_DEF \
 	X(NTFS, "ntfs", "NTFS    ", "ntfsck", "-a", "-C", "-r") \
 	X(EXFAT, "exfat", "EXFAT   ", "fsck.exfat", "-ys", "", "-r") \
-	X(FAT, "fat", "", "dosfsck", "-a", "-C", "-r")
+	X(FAT, "fat", "", "dosfsck", "-afw", "-C", "-r")
 
 /*
  * fstype_t will expand code like as below


### PR DESCRIPTION
check_is_dirty() function also fork each filesystem 'fsck', so adjust the timeout range to include the function.